### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/sachitv/icloud-hide-my-email-browser-plus-extension/security/code-scanning/4](https://github.com/sachitv/icloud-hide-my-email-browser-plus-extension/security/code-scanning/4)

**General approach:**  
Add a `permissions:` block to the workflow file `.github/workflows/tests.yaml` to follow the principle of least privilege. The `permissions:` block should be set at the top-level (workflow-level) so that it applies to all jobs, unless a specific job requires different permissions (none do here). Since jobs only require read access (checkout code, install dependencies, audit, build, check), set `contents: read` as the minimal required permission.

**Specific edits:**  
Insert the following block right after the `name: tests` line and before the `on:` key:
```yaml
permissions:
  contents: read
```

This ensures workflow jobs only have read access to the repository contents using the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
