### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/sachitv/icloud-hide-my-email-browser-plus-extension/security/code-scanning/3](https://github.com/sachitv/icloud-hide-my-email-browser-plus-extension/security/code-scanning/3)

To fix the problem, we need to add an explicit `permissions` block to the workflow to restrict the permissions of the `GITHUB_TOKEN`. The minimal, recommended starting point is `contents: read`, which enables the jobs to fetch the code but does not allow them to write to the repository or modify artifacts, issues, pull requests, etc. This can be done at the root level (so it applies to all jobs) by adding (after the `name:` block but before `on:`):  
```yaml
permissions:
  contents: read
```  
No additional changes are required unless a particular job needs broader permissions (which, in this workflow, it does not). No imports, methods, or other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
