### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/sachitv/icloud-hide-my-email-browser-plus-extension/security/code-scanning/2](https://github.com/sachitv/icloud-hide-my-email-browser-plus-extension/security/code-scanning/2)

The best way to fix this problem is to add an explicit `permissions` block at the root of the workflow file, directly under the workflow `name` field and before the `jobs` section. This will apply the permissions to all jobs in the workflow, ensuring the default `contents` access is explicitly set to `read` (as a minimal starting point). If individual jobs require additional permissions, an explicit job-level `permissions` block can later be added, but for the current workflow, none require more than read access. The changes are to be made in the .github/workflows/tests.yaml file, adding the following block:

```yaml
permissions:
  contents: read
```

directly after the `name: tests` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
