### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/sachitv/icloud-hide-my-email-browser-plus-extension/security/code-scanning/1](https://github.com/sachitv/icloud-hide-my-email-browser-plus-extension/security/code-scanning/1)

To fix this issue, explicitly set the `permissions:` key at the top level of the workflow file, applying it to all jobs unless overridden at the job level. The minimal starting point recommended is `contents: read`, which allows the jobs to clone repository code but nothing else. Because none of the jobs shown require write access to repository content or other resources, keeping permissions minimal is appropriate and matches the principle of least privilege. The change should be made by adding a `permissions:` block at line 2 (right after the `name:` key) in `.github/workflows/tests.yaml`. No other imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
