### PR TITLE
chore: prep firefox build and ci workflow updates

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
 
-  build:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -37,10 +37,70 @@ jobs:
         run: npm ci
       - name: Prettier formatting
         run: npm run prettier:check
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: format
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'npm'
+      - name: Install npm deps
+        run: npm ci
       - name: Lint
         run: npm run lint
-      - name: Build extension
+
+  build-chrome:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'npm'
+      - name: Install npm deps
+        run: npm ci
+      - name: Build extension for Chrome
         run: npm run build
+      - name: Zip Chrome build output
+        run: |
+          cd build
+          zip -r ../icloud-hide-my-email-chrome-extension.zip .
+      - name: Upload Chrome artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: icloud-hide-my-email-chrome-extension
+          path: icloud-hide-my-email-chrome-extension.zip
+
+  build-firefox:
+    runs-on: ubuntu-latest
+    needs: build-chrome
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'npm'
+      - name: Install npm deps
+        run: npm ci
+      - name: Build extension for Firefox
+        # This also lints the Firefox build using web-ext.
+        # In the future add -w to the lint to treat warnings as errors.
+        run: |
+          npm run build:firefox
+          npx web-ext lint --source-dir build
+          npx web-ext build --source-dir build --artifacts-dir . --filename icloud-hide-my-email-firefox-extension.zip
+      - name: Upload Firefox artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: icloud-hide-my-email-firefox-extension
+          path: icloud-hide-my-email-firefox-extension.zip
 
   license-audit:
     needs: detect-license-changes

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -543,7 +543,6 @@
 | [readable-stream@3.6.2](https://github.com/nodejs/readable-stream)                                                     | MIT                           |
 | [rechoir@0.8.0](https://github.com/gulpjs/rechoir)                                                                     | MIT                           |
 | [reflect.getprototypeof@1.0.10](https://github.com/es-shims/Reflect.getPrototypeOf)                                    | MIT                           |
-| [regenerator-runtime@0.14.1](https://github.com/facebook/regenerator.git#main)                                         | MIT                           |
 | [regexp.prototype.flags@1.5.4](https://github.com/es-shims/RegExp.prototype.flags)                                     | MIT                           |
 | [relateurl@0.2.7](https://github.com/stevenvachon/relateurl)                                                           | MIT                           |
 | [renderkid@3.0.0](https://github.com/AriaMinaei/RenderKid)                                                             | MIT                           |

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -66,9 +66,6 @@
 | [@types/http-proxy@1.17.16](https://github.com/DefinitelyTyped/DefinitelyTyped)                                        | MIT                           |
 | [@types/json-schema@7.0.15](https://github.com/DefinitelyTyped/DefinitelyTyped)                                        | MIT                           |
 | [@types/json5@0.0.29](https://github.com/DefinitelyTyped/DefinitelyTyped)                                              | MIT                           |
-| [@types/lodash.isequal@4.5.8](https://github.com/DefinitelyTyped/DefinitelyTyped)                                      | MIT                           |
-| [@types/lodash.startcase@4.4.9](https://github.com/DefinitelyTyped/DefinitelyTyped)                                    | MIT                           |
-| [@types/lodash@4.17.20](https://github.com/DefinitelyTyped/DefinitelyTyped)                                            | MIT                           |
 | [@types/mime@1.3.5](https://github.com/DefinitelyTyped/DefinitelyTyped)                                                | MIT                           |
 | [@types/minimatch@5.1.2](https://github.com/DefinitelyTyped/DefinitelyTyped)                                           | MIT                           |
 | [@types/node-forge@1.3.14](https://github.com/DefinitelyTyped/DefinitelyTyped)                                         | MIT                           |
@@ -423,9 +420,7 @@
 | [locate-path@5.0.0](https://github.com/sindresorhus/locate-path)                                                       | MIT                           |
 | [locate-path@6.0.0](https://github.com/sindresorhus/locate-path)                                                       | MIT                           |
 | [lodash.clonedeep@4.5.0](https://github.com/lodash/lodash)                                                             | MIT                           |
-| [lodash.isequal@4.5.0](https://github.com/lodash/lodash)                                                               | MIT                           |
 | [lodash.merge@4.6.2](https://github.com/lodash/lodash)                                                                 | MIT                           |
-| [lodash.startcase@4.4.0](https://github.com/lodash/lodash)                                                             | MIT                           |
 | [lodash@4.17.21](https://github.com/lodash/lodash)                                                                     | MIT                           |
 | [loose-envify@1.4.0](https://github.com/zertosh/loose-envify)                                                          | MIT                           |
 | [lower-case@2.0.2](https://github.com/blakeembrey/change-case)                                                         | MIT                           |

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,6 @@
         "@fortawesome/free-solid-svg-icons": "^7.0.1",
         "@fortawesome/react-fontawesome": "^3.0.2",
         "fuse.js": "^7.1.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.startcase": "^4.4.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "uuid": "^13.0.0",
@@ -24,8 +22,6 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.13",
         "@types/chrome": "^0.1.12",
-        "@types/lodash.isequal": "^4.5.8",
-        "@types/lodash.startcase": "^4.4.9",
         "@types/react": "^19.1.14",
         "@types/react-dom": "^19.1.9",
         "@types/webextension-polyfill": "^0.12.3",
@@ -1152,27 +1148,6 @@
       "version": "0.0.29",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.20",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash.isequal": {
-      "version": "4.5.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.startcase": {
-      "version": "4.4.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -5841,17 +5816,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.startcase": {
-      "version": "4.4.0",
       "license": "MIT"
     },
     "node_modules/loose-envify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "icloud-hide-my-email-browser-extension",
-  "version": "1.3.0",
+  "name": "icloud-hide-my-email-plus-browser-extension",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "icloud-hide-my-email-browser-extension",
-      "version": "1.3.0",
+      "name": "icloud-hide-my-email-plus-browser-extension",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.0.1",
@@ -18,7 +18,6 @@
         "lodash.startcase": "^4.4.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "regenerator-runtime": "^0.14.1",
         "uuid": "^13.0.0",
         "webextension-polyfill": "^0.12.0"
       },
@@ -7238,12 +7237,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "@fortawesome/free-solid-svg-icons": "^7.0.1",
     "@fortawesome/react-fontawesome": "^3.0.2",
     "fuse.js": "^7.1.0",
-    "lodash.isequal": "^4.5.0",
-    "lodash.startcase": "^4.4.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "uuid": "^13.0.0",
@@ -37,8 +35,6 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.13",
     "@types/chrome": "^0.1.12",
-    "@types/lodash.isequal": "^4.5.8",
-    "@types/lodash.startcase": "^4.4.9",
     "@types/react": "^19.1.14",
     "@types/react-dom": "^19.1.9",
     "@types/webextension-polyfill": "^0.12.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lodash.startcase": "^4.4.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "regenerator-runtime": "^0.14.1",
     "uuid": "^13.0.0",
     "webextension-polyfill": "^0.12.0"
   },

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -5,12 +5,12 @@ import {
   SetStateAction,
   useCallback,
 } from 'react';
-import isEqual from 'lodash.isequal';
 import {
   getBrowserStorageValue,
   setBrowserStorageValue,
   Store,
 } from './storage';
+import { deepEqual } from './utils/deepEqual';
 
 export function useBrowserStorageState<K extends keyof Store>(
   key: K,
@@ -26,7 +26,7 @@ export function useBrowserStorageState<K extends keyof Store>(
 
       value !== undefined &&
         setState((prevState) =>
-          isEqual(prevState, value) ? prevState : value
+          deepEqual(prevState, value) ? prevState : value
         );
     }
 

--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -1,4 +1,3 @@
-import 'regenerator-runtime/runtime.js';
 import {
   getBrowserStorageValue,
   setBrowserStorageValue,

--- a/src/pages/Content/script.ts
+++ b/src/pages/Content/script.ts
@@ -39,7 +39,7 @@ const disableButton = (
   cursorClass: string,
   copy: string
 ): void => {
-  btn.innerHTML = copy;
+  btn.textContent = copy;
   btn.setAttribute('disabled', 'true');
   btn.classList.remove(className('hover-button'));
   btn.classList.forEach((name) => {
@@ -55,7 +55,7 @@ const enableButton = (
   cursorClass: string,
   copy: string
 ): void => {
-  btn.innerHTML = copy;
+  btn.textContent = copy;
   btn.removeAttribute('disabled');
   btn.classList.add(className('hover-button'));
   btn.classList.forEach((name) => {
@@ -98,7 +98,7 @@ const makeButtonSupport = (
 
   const btnOnMousedownCallback = async (ev: MouseEvent) => {
     ev.preventDefault();
-    const hme = btnElement.innerHTML;
+    const hme = btnElement.textContent ?? '';
     disableButton(btnElement, 'cursor-progress', LOADING_COPY);
     await browser.runtime.sendMessage({
       type: MessageType.ReservationRequest,

--- a/src/pages/Options/Options.tsx
+++ b/src/pages/Options/Options.tsx
@@ -9,9 +9,9 @@ import {
   TitledComponent,
   Link,
 } from '../../commonComponents';
-import startCase from 'lodash.startcase';
-import isEqual from 'lodash.isequal';
 import { DEFAULT_STORE } from '../../storage';
+import { startCase } from '../../utils/startCase';
+import { deepEqual } from '../../utils/deepEqual';
 
 const SELECT_FWD_TO_SIGNED_OUT_CTA_COPY =
   'To select a new Forward-To address, you first need to sign-in by following the instructions on the extension pop-up.';
@@ -49,7 +49,7 @@ const SelectFwdToForm = () => {
         const pms = new PremiumMailSettings(client);
         const result = await pms.listHme();
         setFwdToEmails((prevState) =>
-          isEqual(prevState, result.forwardToEmails)
+          deepEqual(prevState, result.forwardToEmails)
             ? prevState
             : result.forwardToEmails
         );

--- a/src/pages/Popup/Popup.tsx
+++ b/src/pages/Popup/Popup.tsx
@@ -42,7 +42,7 @@ import { setBrowserStorageValue, Store } from '../../storage';
 
 import browser from 'webextension-polyfill';
 import Fuse from 'fuse.js';
-import isEqual from 'lodash.isequal';
+import { deepEqual } from '../../utils/deepEqual';
 import {
   PopupAction,
   PopupState,
@@ -661,14 +661,14 @@ const HmeManager = (props: {
     const newHmeEmail = { ...hmeEmail, isActive: !hmeEmail.isActive };
     setFetchedHmeEmails((prevFetchedHmeEmails) =>
       prevFetchedHmeEmails?.map((item) =>
-        isEqual(item, hmeEmail) ? newHmeEmail : item
+        deepEqual(item, hmeEmail) ? newHmeEmail : item
       )
     );
   };
 
   const deletionCallbackFactory = (hmeEmail: HmeEmail) => () => {
     setFetchedHmeEmails((prevFetchedHmeEmails) =>
-      prevFetchedHmeEmails?.filter((item) => !isEqual(item, hmeEmail))
+      prevFetchedHmeEmails?.filter((item) => !deepEqual(item, hmeEmail))
     );
   };
 

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -1,0 +1,93 @@
+const hasOwn = Object.prototype.hasOwnProperty;
+
+type AnyRecord = Record<string | number | symbol, unknown>;
+
+const deepEqualInternal = (
+  a: unknown,
+  b: unknown,
+  stack: WeakMap<object, object>
+): boolean => {
+  if (Object.is(a, b)) {
+    return true;
+  }
+
+  if (typeof a !== typeof b) {
+    return false;
+  }
+
+  if (a === null || b === null) {
+    return false;
+  }
+
+  if (typeof a !== 'object') {
+    return false;
+  }
+
+  const objectA = a as object;
+  const objectB = b as object;
+
+  if (stack.get(objectA) === objectB) {
+    return true;
+  }
+
+  stack.set(objectA, objectB);
+
+  if (Array.isArray(objectA)) {
+    if (!Array.isArray(objectB)) {
+      return false;
+    }
+
+    if (objectA.length !== objectB.length) {
+      return false;
+    }
+
+    for (let index = 0; index < objectA.length; index += 1) {
+      if (!deepEqualInternal(objectA[index], objectB[index], stack)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  if (objectA instanceof Date && objectB instanceof Date) {
+    return objectA.getTime() === objectB.getTime();
+  }
+
+  const recordA = objectA as AnyRecord;
+  const recordB = objectB as AnyRecord;
+
+  if (Object.getPrototypeOf(recordA) !== Object.getPrototypeOf(recordB)) {
+    return false;
+  }
+
+  const keysA = Reflect.ownKeys(recordA);
+  const keysB = Reflect.ownKeys(recordB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  for (const key of keysA) {
+    if (!hasOwn.call(recordB, key)) {
+      return false;
+    }
+
+    if (
+      !deepEqualInternal(
+        recordA[key as keyof AnyRecord],
+        recordB[key as keyof AnyRecord],
+        stack
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const deepEqual = (a: unknown, b: unknown): boolean =>
+  deepEqualInternal(a, b, new WeakMap());
+
+export default deepEqual;

--- a/src/utils/startCase.ts
+++ b/src/utils/startCase.ts
@@ -1,0 +1,9 @@
+export const startCase = (value: string): string =>
+  value
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+export default startCase;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2024",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
     "skipLibCheck": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,10 +36,19 @@ const applyFirefoxManifestTransformations = (manifest) => {
     ...{
       browser_specific_settings: {
         gecko: {
-          id: '{5f2806a5-f66d-40c6-8fb2-6018753b5626}',
+          id: '{b3b720a0-8bf9-4e1f-b0e2-1e97f6ff708b}',
           // Minimum version of Firefox that supports declarativeNetRequest:
           // https://blog.mozilla.org/addons/2023/05/17/declarativenetrequest-available-in-firefox/
-          strict_min_version: '113.0',
+          strict_min_version: '126.0',
+          data_collection_permissions: {
+            required: ["none"],
+          },
+        },
+        gecko_android: {
+          strict_min_version: '126.0',
+          data_collection_permissions: {
+            required: ["none"],
+          },
         },
       },
     },
@@ -67,6 +76,7 @@ const htmlPages = [
 const htmlEntryNames = htmlPages.map(({ chunk }) => chunk);
 
 const options = {
+  node: false,
   mode: isDev ? 'development' : 'production',
   entry: {
     popup: path.join(__dirname, 'src', 'pages', 'Popup', 'index.tsx'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,13 +41,13 @@ const applyFirefoxManifestTransformations = (manifest) => {
           // https://blog.mozilla.org/addons/2023/05/17/declarativenetrequest-available-in-firefox/
           strict_min_version: '126.0',
           data_collection_permissions: {
-            required: ["none"],
+            required: ['none'],
           },
         },
         gecko_android: {
           strict_min_version: '126.0',
           data_collection_permissions: {
-            required: ["none"],
+            required: ['none'],
           },
         },
       },


### PR DESCRIPTION
## Summary
- replace content script button innerHTML usage with textContent and update reservation handling
- raise TypeScript target, drop regenerator-runtime import, and adjust Firefox manifest metadata
- add deepEqual and startCase utils, remove lodash dependencies, and update hooks, options, and popup usage
- regenerate package-lock and attributions to reflect dependency removals
- restructure tests workflow into format, lint, build-chrome, and build-firefox jobs
- package Chrome and Firefox builds as zipped artifacts in CI runs

## Testing
- not run
