### PR TITLE
Add Edge release automation and tighten workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,12 @@
-name: Release Extensions
-
-permissions:
-  contents: write
+name: Release for Chrome, Firefox, and Edge
 
 on:
   workflow_dispatch:
 
 jobs:
   version:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       extension_version: ${{ steps.package-version.outputs.extension_version }}
@@ -19,11 +18,12 @@ jobs:
           VERSION="$(node -p "require('./package.json').version")"
           echo "extension_version=${VERSION}" >> "$GITHUB_OUTPUT"
   
-  build-chrome:
+  build-chrome-and-edge:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-latest
     needs: version
-    outputs:
-      extension_version: ${{ needs.version.outputs.extension_version }}
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js 22.x
@@ -39,17 +39,25 @@ jobs:
         run: |
           cd build
           zip -r ../icloud-hide-my-email-plus-chrome-extension.zip .
-      - name: Upload build artifact
+      - name: Duplicate Chrome build for Edge
+        run: cp icloud-hide-my-email-plus-chrome-extension.zip icloud-hide-my-email-plus-edge-extension.zip
+      - name: Upload Chrome artifact
         uses: actions/upload-artifact@v4
         with:
           name: icloud-hide-my-email-plus-chrome-extension
           path: icloud-hide-my-email-plus-chrome-extension.zip
+      - name: Upload Edge artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: icloud-hide-my-email-plus-edge-extension
+          path: icloud-hide-my-email-plus-edge-extension.zip
 
   build-firefox:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-latest
     needs: version
-    outputs:
-      extension_version: ${{ needs.version.outputs.extension_version }}
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js 22.x
@@ -71,8 +79,10 @@ jobs:
           path: icloud-hide-my-email-plus-firefox-extension.zip
 
   publish-chrome:
+    permissions:
+      actions: read
     runs-on: ubuntu-latest
-    needs: build-chrome
+    needs: build-chrome-and-edge
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -82,7 +92,7 @@ jobs:
       - name: Publish to Chrome Web Store
         uses: mobilefirstllc/cws-publish@latest
         with:
-          action: 'upload'
+          action: publish
           client_id: ${{ secrets.CHROME_CLIENT_ID }}
           client_secret: ${{ secrets.CHROME_CLIENT_SECRET }}
           refresh_token: ${{ secrets.CHROME_REFRESH_TOKEN }}
@@ -90,6 +100,8 @@ jobs:
           zip_file: artifacts/icloud-hide-my-email-plus-chrome-extension.zip
 
   publish-firefox:
+    permissions:
+      actions: read
     runs-on: ubuntu-latest
     needs: build-firefox
     steps:
@@ -107,16 +119,43 @@ jobs:
           jwt-issuer: ${{ secrets.FIREFOX_JWT_ISSUER }}
           jwt-secret: ${{ secrets.FIREFOX_JWT_SECRET }}
 
+  publish-edge:
+    permissions:
+      actions: read
+    runs-on: ubuntu-latest
+    needs: build-chrome-and-edge
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: icloud-hide-my-email-plus-edge-extension
+          path: artifacts
+      - uses: wdzeng/edge-addon@v2
+        with:
+          product-id: ${{ secrets.MICROSOFT_PRODUCT_ID }}
+          zip-path: artifacts/icloud-hide-my-email-plus-edge-extension.zip
+          api-key: ${{ secrets.MICROSOFT_API_KEY }}
+          client-id: ${{ secrets.MICROSOFT_CLIENT_ID }}
+
   create-release:
+    permissions:
+      contents: write
+      actions: read
     runs-on: ubuntu-latest
     needs:
-      - build-chrome
+      - build-chrome-and-edge
       - build-firefox
+      - version
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
           name: icloud-hide-my-email-plus-chrome-extension
+          path: artifacts
+      - name: Download Edge artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: icloud-hide-my-email-plus-edge-extension
           path: artifacts
       - name: Download Firefox artifact
         uses: actions/download-artifact@v4
@@ -126,10 +165,11 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ needs.build-chrome.outputs.extension_version }}
-          name: v${{ needs.build-chrome.outputs.extension_version }}
+          tag_name: v${{ needs.version.outputs.extension_version }}
+          name: v${{ needs.version.outputs.extension_version }}
           body: |
-            Automated release for version ${{ needs.build-chrome.outputs.extension_version }}.
+            Automated release for version v${{ needs.version.outputs.extension_version }}
           files: |
             artifacts/icloud-hide-my-email-plus-chrome-extension.zip
+            artifacts/icloud-hide-my-email-plus-edge-extension.zip
             artifacts/icloud-hide-my-email-plus-firefox-extension.zip

--- a/README.md
+++ b/README.md
@@ -78,7 +78,3 @@ Note: the following console commands are to be executed from the root directory 
 | 5 | Compress productionized artifact | `zip build.zip ./build/*` | `web-ext -s build build` |
 | 6 | Publish | [Chrome Web Store developer console](https://chrome.google.com/webstore/devconsole/) | [Mozilla Add-on Developer Hub](https://addons.mozilla.org/en-US/developers/addon/icloud-hide-my-email/versions/submit/) |
 <!-- prettier-ignore-end -->
-
-### TODOs
-
-- [ ] Continuous Deployment


### PR DESCRIPTION
## Summary
- duplicate the Chrome bundle to create an Edge artifact and upload it through the Microsoft Store action
- scope each job’s permissions and reuse the shared build output for Chrome, Edge, and release packaging
- update the release metadata to read the version job output and remove the obsolete "Continuous Deployment" TODO

## Testing
- Not run (workflow changes only)
