### PR TITLE
chore: consolidate duplicate string constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@ export const CONTEXT_MENU_ITEM_ID = browser.runtime.id.concat(
   'hme_generation_and_reservation'
 );
 
-export const SIGNED_OUT_CTA_COPY = 'Please sign in to iCloud';
+export const SIGNED_OUT_COPY = 'Please sign in to iCloud';
 export const LOADING_COPY = 'Hide My Email+ — Loading...';
 export const SIGNED_IN_CTA_COPY = 'Generate and reserve a Hide My Email+ alias';
 export const NOTIFICATION_MESSAGE_COPY =

--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -24,8 +24,8 @@ import {
   NOTIFICATION_MESSAGE_COPY,
   NOTIFICATION_TITLE_COPY,
   SIGNED_IN_CTA_COPY,
-  SIGNED_OUT_CTA_COPY,
-} from './constants';
+  SIGNED_OUT_COPY,
+} from '../../constants';
 import { isFirefox } from '../../browserUtils';
 
 const constructClient = async (): Promise<ICloudClient> => {
@@ -47,7 +47,7 @@ const performDeauthSideEffects = async () => {
 
   browser.contextMenus
     .update(CONTEXT_MENU_ITEM_ID, {
-      title: SIGNED_OUT_CTA_COPY,
+      title: SIGNED_OUT_COPY,
       enabled: false,
     })
     .catch(console.debug);
@@ -93,7 +93,7 @@ browser.runtime.onMessage.addListener(async (uncastedMessage: unknown) => {
       {
         const deauthCallback = async () => {
           await sendMessageToTab(MessageType.GenerateResponse, {
-            error: SIGNED_OUT_CTA_COPY,
+            error: SIGNED_OUT_COPY,
             elementId,
           });
           await performDeauthSideEffects();
@@ -251,7 +251,7 @@ browser.contextMenus.onClicked.addListener(async (info, tab) => {
     sendMessageToTab(
       MessageType.ActiveInputElementWrite,
       {
-        text: SIGNED_OUT_CTA_COPY,
+        text: SIGNED_OUT_COPY,
         copyToClipboard: false,
       } as ActiveInputElementWriteData,
       tab

--- a/src/pages/Content/script.ts
+++ b/src/pages/Content/script.ts
@@ -8,12 +8,10 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import browser from 'webextension-polyfill';
 import { getBrowserStorageValue } from '../../storage';
+import { LOADING_COPY, SIGNED_OUT_COPY } from '../../constants';
 
 const EMAIL_INPUT_QUERY_STRING =
   'input[type="email"], input[name="email"], input[id="email"]';
-
-const LOADING_COPY = 'Hide My Email+ — Loading...';
-const SIGNED_OUT_COPY = 'Please sign in to iCloud';
 
 // A unique CSS class prefix is used to guarantee that the style injected
 // by the extension does not interfere with the existing style of

--- a/src/pages/Popup/Popup.tsx
+++ b/src/pages/Popup/Popup.tsx
@@ -53,8 +53,8 @@ import {
 } from './stateMachine';
 import {
   CONTEXT_MENU_ITEM_ID,
-  SIGNED_OUT_CTA_COPY,
-} from '../Background/constants';
+  SIGNED_OUT_COPY,
+} from '../../constants';
 import { isFirefox } from '../../browserUtils';
 
 type TransitionCallback<T extends PopupAction> = (action: T) => void;
@@ -235,7 +235,7 @@ const FooterButton = (
 async function performDeauthSideEffects(): Promise<void> {
   await browser.contextMenus
     .update(CONTEXT_MENU_ITEM_ID, {
-      title: SIGNED_OUT_CTA_COPY,
+      title: SIGNED_OUT_COPY,
       enabled: false,
     })
     .catch((error) => {

--- a/tests/contentScript.helpers.test.ts
+++ b/tests/contentScript.helpers.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 vi.mock('webextension-polyfill', () => ({
   default: {
     runtime: {
+      id: 'test-extension-id',
       sendMessage: vi.fn(),
       onMessage: {
         addListener: vi.fn(),

--- a/tests/contentScript.test.ts
+++ b/tests/contentScript.test.ts
@@ -38,6 +38,7 @@ let runtimeMessageListener: ((message: unknown) => void) | undefined;
 vi.mock('webextension-polyfill', () => ({
   default: {
     runtime: {
+      id: 'test-extension-id',
       sendMessage: runtimeSendMessageMock,
       onMessage: {
         addListener: runtimeOnMessageAddListenerMock,

--- a/tests/popup.test.tsx
+++ b/tests/popup.test.tsx
@@ -12,7 +12,7 @@ import {
 } from 'vitest';
 import Popup from '../src/pages/Popup/Popup';
 import { PopupState } from '../src/pages/Popup/stateMachine';
-import { CONTEXT_MENU_ITEM_ID } from '../src/pages/Background/constants';
+import { CONTEXT_MENU_ITEM_ID } from '../src/constants';
 import { createHmeEmailTestData, createClientStateTestData } from './testUtils';
 
 const {


### PR DESCRIPTION
🎯 **What:** Consolidated string constants (`LOADING_COPY`, `SIGNED_OUT_COPY`) into a central `src/constants.ts` file, resolving duplication. Renamed `SIGNED_OUT_CTA_COPY` to `SIGNED_OUT_COPY` for consistency. Added a mock for `browser.runtime.id` in tests to support evaluating the new shared constants module.

💡 **Why:** Reduces duplicate code blocks and makes updating user-facing copy safer and consistent across all extension scripts (Background, Popup, Content).

✅ **Verification:** Verified by running all unit tests via `npm run test:coverage` (100% coverage, all 131 tests passing) and format/linting via `npm run lint:check`. No errors were found.

✨ **Result:** Improved maintainability by having a single source of truth for UI copy, resulting in slightly cleaner individual files.

---
*PR created automatically by Jules for task [8628658404954694724](https://jules.google.com/task/8628658404954694724) started by @sachitv*