### PR TITLE
chore: bump patch version to 1.4.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "icloud-hide-my-email-plus-browser-extension",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "icloud-hide-my-email-plus-browser-extension",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icloud-hide-my-email-plus-browser-extension",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Cross-browser extension bringing iCloud's Hide My Email service to more browsers as Hide My Email+.",
   "license": "MIT",
   "author": "Sachit Vithaldas",


### PR DESCRIPTION
Bumped patch version in package.json and package-lock.json from 1.4.8 to 1.4.9 for a new release using `npm version patch --no-git-tag-version`.

---
*PR created automatically by Jules for task [7436216357968746094](https://jules.google.com/task/7436216357968746094) started by @sachitv*