### PR TITLE
chore: bump version to 1.4.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "icloud-hide-my-email-plus-browser-extension",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "icloud-hide-my-email-plus-browser-extension",
-      "version": "1.4.9",
+      "version": "1.4.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icloud-hide-my-email-plus-browser-extension",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "Cross-browser extension bringing iCloud's Hide My Email service to more browsers as Hide My Email+.",
   "license": "MIT",
   "author": "Sachit Vithaldas",


### PR DESCRIPTION
Automated patch version bump (1.4.9 → 1.4.10). Only package.json and package-lock.json updated. No code changes.