### PR TITLE
test: add missing assertions to ignores reservation response test

### DIFF
--- a/tests/contentScript.test.ts
+++ b/tests/contentScript.test.ts
@@ -811,21 +811,25 @@ describe('content script email button integration', () => {
 
     await runContentScript();
 
-    sendRuntimeMessage({
-      type: MessageType.ReservationResponse,
-      data: {
-        elementId: 'missing',
-        hme: 'ignored',
-      },
-    });
+    expect(() => {
+      sendRuntimeMessage({
+        type: MessageType.ReservationResponse,
+        data: {
+          elementId: 'missing',
+          hme: 'ignored',
+        },
+      });
+    }).not.toThrow();
 
-    sendRuntimeMessage({
-      type: MessageType.ReservationResponse,
-      data: {
-        elementId: 'missing',
-        error: 'still ignored',
-      },
-    });
+    expect(() => {
+      sendRuntimeMessage({
+        type: MessageType.ReservationResponse,
+        data: {
+          elementId: 'missing',
+          error: 'still ignored',
+        },
+      });
+    }).not.toThrow();
   });
 
   // Exercises the default case to ensure unknown messages are ignored.


### PR DESCRIPTION
Adds explicit `.not.toThrow()` assertions to the `ignores reservation responses when no button is present` test in `contentScript.test.ts` to ensure it properly validates that invalid reservation responses are gracefully ignored without erroring.

---
*PR created automatically by Jules for task [4245983241023192941](https://jules.google.com/task/4245983241023192941) started by @sachitv*