### PR TITLE
chore: bump version to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "icloud-hide-my-email-plus-browser-extension",
-  "version": "1.4.11",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "icloud-hide-my-email-plus-browser-extension",
-      "version": "1.4.11",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icloud-hide-my-email-plus-browser-extension",
-  "version": "1.4.11",
+  "version": "1.5.0",
   "description": "Cross-browser extension bringing iCloud's Hide My Email service to more browsers as Hide My Email+.",
   "license": "MIT",
   "author": "Sachit Vithaldas",


### PR DESCRIPTION
## Summary
- Bump package version from 1.4.11 to 1.5.0
- Update package-lock root metadata

## Validation
- npm run biome:format:check
- npm run lint:check