### PR TITLE
chore: bump version to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "icloud-hide-my-email-plus-browser-extension",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "icloud-hide-my-email-plus-browser-extension",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icloud-hide-my-email-plus-browser-extension",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Cross-browser extension bringing iCloud's Hide My Email service to more browsers as Hide My Email+.",
   "license": "MIT",
   "author": "Sachit Vithaldas",


### PR DESCRIPTION
Bumps the extension version from 1.5.0 to 1.5.1 in preparation for a release.

## Why a patch bump

Everything merged since `v1.5.0` is dev-tooling or docs — no runtime dependency or extension code changed:

- #303 vitest group (2 updates)
- #304 publish-browser-extension 4.0.5 → 6.0.0
- #305 postcss 8.5.15 → 8.5.24
- #306 storybook 10.4.6 → 10.5.5
- #307 @tailwindcss/postcss 4.3.1 → 4.3.3
- #308 actions/setup-node 6 → 7
- #311 fast-uri 3.1.2 → 3.1.5
- #302, #310 ATTRIBUTIONS.md refreshes

## Changes

- `package.json` / `package-lock.json`: `1.5.0` → `1.5.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)