### PR TITLE
chore: bump version to 1.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "icloud-hide-my-email-plus-browser-extension",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "icloud-hide-my-email-plus-browser-extension",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icloud-hide-my-email-plus-browser-extension",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Cross-browser extension bringing iCloud's Hide My Email service to more browsers as Hide My Email+.",
   "license": "MIT",
   "author": "Sachit Vithaldas",


### PR DESCRIPTION
Bumps the extension version from 1.5.2 to 1.5.3 in preparation for a release.

## Why a patch bump

Everything merged since `v1.5.2` is dev-tooling, dependency bumps, or the attributions refresh — no runtime dependency or extension code changed:

- #319 ATTRIBUTIONS.md refresh
- #320 brace-expansion 1.1.15 → 1.1.18
- #322 undici 6.27.0 → 6.28.0
- #323 react group (2 updates)
- #324 @playwright/test 1.61.0 → 1.62.1
- #325 ip-address 10.2.0 → 10.5.0
- #326 js-yaml 4.2.0 → 4.3.1

## Changes

- `package.json` / `package-lock.json`: `1.5.2` → `1.5.3`