### PR TITLE
chore(deps-dev): update publish-browser-extension to 6.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "license-checker-rseidelsohn": "^5.0.1",
         "postcss": "^8.5.24",
         "prettier": "^3.8.1",
-        "publish-browser-extension": "^6.0.0",
+        "publish-browser-extension": "^6.1.1",
         "spdx-expression-parse": "^4.0.0",
         "storybook": "^10.5.5",
         "tailwindcss": "^4.3.2",
@@ -10221,9 +10221,9 @@
       "license": "ISC"
     },
     "node_modules/publish-browser-extension": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/publish-browser-extension/-/publish-browser-extension-6.0.0.tgz",
-      "integrity": "sha512-DStg6sPhxBBECBQmx2hAT3MJY0BIdkx1JCiL3laowL/QHi4Wi2mE3BXCGMXFgU63b2T9JVR+9uD8XPASfZIQhA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/publish-browser-extension/-/publish-browser-extension-6.1.1.tgz",
+      "integrity": "sha512-ovfBOz+cZIOBHZ+oxTfpv1kSGU7ruzy8CXoFGvhXsUbJuty45srGzf1ufEePs69virOWXfFbhZRoNQUdgPvwXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "license-checker-rseidelsohn": "^5.0.1",
     "postcss": "^8.5.24",
     "prettier": "^3.8.1",
-    "publish-browser-extension": "^6.0.0",
+    "publish-browser-extension": "^6.1.1",
     "spdx-expression-parse": "^4.0.0",
     "storybook": "^10.5.5",
     "tailwindcss": "^4.3.2",


### PR DESCRIPTION
Updates only the direct root publisher from `^6.0.0` to `^6.1.1`.

The previous release failed on Firefox AMO because `publish-browser-extension@6.0.0` omitted the ZIP filename from multipart uploads. Upstream issue [#90](https://github.com/aklinker1/publish-browser-extension/issues/90) reports the same error, and [#91](https://github.com/aklinker1/publish-browser-extension/pull/91) fixes it by including filenames in Firefox ZIP uploads.

Validation passed:
- 278 unit tests
- lint and formatting checks
- license check
- Firefox package build
- release-build validation
- Firefox `web-ext lint`

The WXT-nested `publish-browser-extension@4.0.5` copy, application code, release workflow, and version PR #327 are intentionally unchanged.