### PR TITLE
chore(deps): remediate transitive npm vulnerabilities

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -167,7 +167,7 @@ This extension is based on the [Hide My Email browser extension](https://github.
 | [addons-linter@10.8.0](https://github.com/mozilla/addons-linter)                                                             | MPL-2.0                             |
 | [addons-moz-compare@1.3.0](https://github.com/mozilla/addons-moz-compare)                                                    | MPL-2.0                             |
 | [addons-scanner-utils@15.4.0](https://github.com/mozilla/addons-scanner-utils)                                               | MPL-2.0                             |
-| [adm-zip@0.5.17](https://github.com/cthackers/adm-zip)                                                                       | MIT                                 |
+| [adm-zip@0.6.0](https://github.com/cthackers/adm-zip)                                                                        | MIT                                 |
 | [agent-base@7.1.4](https://github.com/TooTallNate/proxy-agents)                                                              | MIT                                 |
 | [ajv@6.15.0](https://github.com/ajv-validator/ajv)                                                                           | MIT                                 |
 | [ajv@8.20.0](https://github.com/ajv-validator/ajv)                                                                           | MIT                                 |
@@ -501,7 +501,7 @@ This extension is based on the [Hide My Email browser extension](https://github.
 | [ms@2.1.3](https://github.com/vercel/ms)                                                                                     | MIT                                 |
 | [multimatch@6.0.0](https://github.com/sindresorhus/multimatch)                                                               | MIT                                 |
 | [nano-spawn@2.1.0](https://github.com/sindresorhus/nano-spawn)                                                               | MIT                                 |
-| [nanoid@3.3.16](https://github.com/ai/nanoid)                                                                                | MIT                                 |
+| [nanoid@3.3.17](https://github.com/ai/nanoid)                                                                                | MIT                                 |
 | [nanospinner@1.2.2](https://github.com/usmanyunusov/nanospinner)                                                             | MIT                                 |
 | [natural-compare@1.4.0](https://github.com/litejs/natural-compare-lite)                                                      | MIT                                 |
 | [negotiator@1.0.0](https://github.com/jshttp/negotiator)                                                                     | MIT                                 |
@@ -627,7 +627,7 @@ This extension is based on the [Hide My Email browser extension](https://github.
 | [setimmediate@1.0.5](https://github.com/YuzuJS/setImmediate)                                                                 | MIT                                 |
 | [shebang-command@2.0.0](https://github.com/kevva/shebang-command)                                                            | MIT                                 |
 | [shebang-regex@3.0.0](https://github.com/sindresorhus/shebang-regex)                                                         | MIT                                 |
-| [shell-quote@1.8.4](https://github.com/ljharb/shell-quote)                                                                   | MIT                                 |
+| [shell-quote@1.9.0](https://github.com/ljharb/shell-quote)                                                                   | MIT                                 |
 | [shellwords@0.1.1](https://github.com/jimmycuadra/shellwords)                                                                | MIT                                 |
 | [siginfo@2.0.0](https://github.com/emilbayes/siginfo)                                                                        | ISC                                 |
 | [signal-exit@4.1.0](https://github.com/tapjs/signal-exit)                                                                    | ISC                                 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -4800,12 +4800,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -7060,6 +7060,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/fx-runner/node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fx-runner/node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -9064,24 +9077,6 @@
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/nanospinner": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
@@ -10061,6 +10056,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
@@ -10754,18 +10767,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shellwords": {
@@ -12453,6 +12454,18 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
+      }
+    },
+    "node_modules/web-ext-run/node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/web-ext-run/node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -84,9 +84,11 @@
     "wxt": "^0.20.27"
   },
   "overrides": {
-    "shell-quote": ">=1.8.4",
+    "shell-quote": "1.9.0",
     "tmp": ">=0.2.6",
     "esbuild": ">=0.28.1",
+    "nanoid": "3.3.17",
+    "adm-zip": "0.6.0",
     "node-notifier": {
       "uuid": ">=11.1.1"
     }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "shell-quote": "1.9.0",
     "tmp": ">=0.2.6",
     "esbuild": ">=0.28.1",
-    "nanoid": "3.3.17",
     "adm-zip": "0.6.0",
     "node-notifier": {
       "uuid": ">=11.1.1"


### PR DESCRIPTION
## Summary
This PR remediates the three reported transitive dependency advisories without upgrading `wxt`, `web-ext`, or other parent tooling.

- `shell-quote` resolves to `1.9.0` through both `fx-runner` paths.
- `adm-zip` resolves to `0.6.0` through `firefox-profile`.
- `nanoid` resolves to `3.3.17` through PostCSS without an override because PostCSS declares the compatible range `^3.3.16`.
- `package-lock.json` and `ATTRIBUTIONS.md` reflect the final dependency tree.

## Why Two Overrides Remain

- `fx-runner` requests exact vulnerable `shell-quote` versions (`1.8.4` and `1.7.3`), so a lockfile-only bump would violate its dependency ranges.
- `firefox-profile` requests `adm-zip` `~0.5.x`, which excludes patched `0.6.0`; the override is required unless the parent tooling is upgraded.
- `nanoid@3.3.17` satisfies PostCSS's existing range, so no override is needed.

## Validation

- `npm ci`
- `npm audit --omit=dev`: 0 vulnerabilities
- `npm test`: 278 tests passed
- `npm run test:e2e`: 4 tests passed
- Brave, Chrome, Edge, and Firefox production builds and release checks
- Firefox `web-ext lint`: 0 errors
- `npm run lint:check`
- `npm run prettier:check`
- `npm run check:licenses`

Full `npm audit` still reports four unrelated existing advisories in `web-ext`/`addons-linter`/`image-size` and `tar`.