### PR TITLE
chore(deps): bump tar to 7.5.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11045,9 +11045,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
## Summary
Bump the transitive `tar` dependency from `7.5.19` to `7.5.22` to resolve GHSA-r292-9mhp-454m (uncontrolled recursion DoS, affected `<=7.5.20`).

Lockfile-only change: both parents already permit the patched version.
- `node-gyp@12.4.0` requires `tar@^7.5.4`
- `pacote@21.5.1` requires `tar@^7.4.3`

## Validation
- `npm ci`
- `npm ls tar` → `7.5.22`
- `npm audit` → `tar` advisory gone
- `npm test` (278 passed)
- `npm run lint:check`
- `npm run biome:format:check`
- `npm run prettier:check`
- `npm run check:licenses`

## Remaining advisories (not addressed here)
- `image-size@2.0.2` via `addons-linter@10.10.0` → `web-ext` → `wxt`: affected range is `<=2.0.2`, and **`2.0.2` is the latest published release** (GHSA-w3rx-r6r6-pgpr, GHSA-5p2g-fcmc-qvqq). No patched upstream version exists yet, and `addons-linter@10.10.0` pins `image-size@2.0.2` exactly, so it cannot be remediated until upstream publishes a fix.